### PR TITLE
Remove explicit engines setting from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
   },
   "author": "Mike Bannister <mikebannister@gmail.com>",
   "license": "MIT",
-  "engines": {
-    "node": "6.x.x"
-  },
   "scripts": {
     "dev": "rimraf lib && babel src --out-dir lib --watch",
     "build": "rimraf lib && babel src --out-dir lib",


### PR DESCRIPTION
Doesn't seem to be any reason to specify it, this makes the package compatible with node v7 as well