### PR TITLE
Make GitHub URLs configurable

### DIFF
--- a/src/decorators/GithubContext.js
+++ b/src/decorators/GithubContext.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import request from 'axios'
 import NextGlobalClientStore from '../modules/NextGlobalClientStore'
+const GITHUB_API_URL = process.env.GITHUB_API_URL || 'https://api.github.com'
 
 const getGithubAccessToken = req => {
   if (process.browser) {
@@ -27,7 +28,7 @@ const getGithubUser = async githubAccessToken => {
     return NextGlobalClientStore.get('githubUser')
   }
 
-  const url = `https://api.github.com/user`
+  const url = `${GITHUB_API_URL}/user`
   const headers = { Authorization: `token ${githubAccessToken}` }
   const options = { headers }
 

--- a/src/modules/getGithubAuthorizeUrl.js
+++ b/src/modules/getGithubAuthorizeUrl.js
@@ -1,4 +1,5 @@
-const githubAuthorizeUrl = 'https://github.com/login/oauth/authorize'
+const GITHUB_URL = process.env.GITHUB_URL || 'https://github.com'
+const githubAuthorizeUrl = `${GITHUB_URL}/login/oauth/authorize`
 
 const queryStringFromObj = queryObj =>
   Object.keys(queryObj)

--- a/src/pages/SignIn.js
+++ b/src/pages/SignIn.js
@@ -6,7 +6,8 @@ import getGithubAccessTokenCookie from '../modules/getGithubAccessTokenCookie'
 import getGithubAuthorizeUrl from '../modules/getGithubAuthorizeUrl'
 import PublicPage from '../decorators/PublicPage'
 
-const githubAccessTokenUrl = 'https://github.com/login/oauth/access_token'
+const GITHUB_URL = process.env.GITHUB_URL || 'https://github.com'
+const githubAccessTokenUrl = `${GITHUB_URL}/login/oauth/access_token`
 const githubClientSecret = demandEnvVar('GITHUB_CLIENT_SECRET')
 
 const fetchGithubAccessToken = async (githubAuthCode, githubClientId) => {


### PR DESCRIPTION
This doesn't change any behaviour by default, but makes it so that a different GitHub URL and GitHub API URL can be set via `process.env` if required (e.g. for use with a GitHub Enterprise installation).